### PR TITLE
Support code with old style classes at runtime

### DIFF
--- a/_pydevd_bundle/pydevd_utils.py
+++ b/_pydevd_bundle/pydevd_utils.py
@@ -134,7 +134,10 @@ def get_clsname_for_code(code, frame):
             if inspect.isclass(first_arg_obj):  # class method
                 first_arg_class = first_arg_obj
             else:  # instance method
-                first_arg_class = first_arg_obj.__class__
+                if hasattr(first_arg_obj, "__class__"):
+                    first_arg_class = first_arg_obj.__class__
+                else: # old style class, fall back on type
+                    first_arg_class = type(first_arg_obj)
             func_name = code.co_name
             if hasattr(first_arg_class, func_name):
                 method = getattr(first_arg_class, func_name)


### PR DESCRIPTION
Old style classes do not have a `__class__` attribute. This code thus would so far fail with an `AttributeError`:

```
Traceback (most recent call last):
  File "C:\Program Files\JetBrains\PyCharm 2019.3.4\plugins\python\helpers\pydev\_pydevd_bundle\pydevd_signature.py", line 97, in create_signature
    _, modulename, funcname = self.file_module_function_of(frame)
  File "C:\Program Files\JetBrains\PyCharm 2019.3.4\plugins\python\helpers\pydev\_pydevd_bundle\pydevd_signature.py", line 122, in file_module_function_of
    clsname = get_clsname_for_code(code, frame)
  File "C:\Program Files\JetBrains\PyCharm 2019.3.4\plugins\python\helpers\pydev\_pydevd_bundle\pydevd_utils.py", line 134, in get_clsname_for_code
    first_arg_class = first_arg_obj.__class__
AttributeError: __class__
```

Specifically this code would cause exceptions from the debugger when debugging code that referenced [`xml.etree.Element`](https://github.com/python/cpython/blob/686d508c26fafb57dfe463c4f55b20013dad1441/Lib/xml/etree/ElementTree.py#L125) instances at runtime, as utilized by the markdown library.

I've been applying this patch to my local PyCharm debugger for the past four or five years now after every single upgrade and just thought it might make sense to try to get it into upstream ;)